### PR TITLE
add optional base64 cred arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnrpc-node-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "eslint-check": "eslint --print-config . | eslint-config-prettier-check"
+    "eslint-check": "eslint . | eslint-config-prettier-check"
   },
   "repository": "https://github.com/Tierion/lnrpc-node-client.git",
   "keywords": [
@@ -43,6 +43,7 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.5.2",
     "bluebird": "^3.5.5",
-    "grpc": "^1.23.3"
+    "grpc": "^1.23.3",
+    "is-base64": "1.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -40,18 +40,18 @@ exports.promisifyGrpc = () => {
 }
 
 // use setCredentials to initialize authenticated grpc connection. If both
-exports.setCredentials = (socketAddr, macaroonData, tlsCertData) => {
+exports.setCredentials = (socketAddr, macaroonValue, tlsCertValue) => {
   let m
   let lndCert
-  if (isBase64(macaroonData)) {
-    m = Buffer.from(macaroon, 'base64')
+  if (isBase64(macaroonValue)) {
+    m = Buffer.from(macaroonValue, 'base64')
   } else {
-    m = fs.readFileSync(macaroonData)
+    m = fs.readFileSync(macaroonValue)
   }
-  if (isBase64(tlsCertData)) {
-    lndCert = Buffer.from(tlsCertData, 'base64')
+  if (isBase64(tlsCertValue)) {
+    lndCert = Buffer.from(tlsCertValue, 'base64')
   } else {
-    lndCert = fs.readFileSync(tlsCertData)
+    lndCert = fs.readFileSync(tlsCertValue)
   }
 
   var macaroon = m.toString('hex')
@@ -78,12 +78,12 @@ exports.setCredentials = (socketAddr, macaroonData, tlsCertData) => {
 }
 
 // use setTls to initialize unauthenticated grpc connection
-exports.setTls = (socketAddr, tlsCertData) => {
+exports.setTls = (socketAddr, tlsCertValue) => {
   let lndCert
-  if (isBase64(tlsCertData)) {
-    lndCert = Buffer.from(tlsCertData, 'base64')
+  if (isBase64(tlsCertValue)) {
+    lndCert = Buffer.from(tlsCertValue, 'base64')
   } else {
-    lndCert = fs.readFileSync(tlsCertData)
+    lndCert = fs.readFileSync(tlsCertValue)
   }
 
   const lnrpcDescriptor = grpc.loadPackageDefinition(rpcDefinition)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,6 +1054,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-base64@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-base64/-/is-base64-1.0.0.tgz#0bdda1a758fcfac6d78df8bb95960512bb42db61"
+  integrity sha512-7McBWBgGDHS8OHvCnPVVxl3HdzitV6XyjM1x7vVxbzXIKJUzxphU5MDL986aZ/oKf/Q+j4Vh4m54Fjwi88n75g==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"


### PR DESCRIPTION
To assist buck in making transition from ln-service to lnrpc-node-client. 

Both setCredentials and setTls now optionally accept their macaroon/tls arguments as base64. Filepath is still supported. 